### PR TITLE
Fixed typo in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "type": "git",
     "url": "github:pedily/use-local-storage"
   },
-  "homepage": "https://github.com/pedilz/use-local-storage#readme",
+  "homepage": "https://github.com/pedily/use-local-storage#readme",
   "scripts": {
     "build": "tsc -p .",
     "prepare": "npm run build"


### PR DESCRIPTION
Fixed the typo in the `homepage` field of the package.json (#1).